### PR TITLE
Remove netlify redirect for flexdashboard, use github pages

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -4,7 +4,6 @@
 /blogdown/*         https://blogdown-pkg.netlify.app/:splat      200
 /rmarkdown/*        https://rmarkdown-pkg.netlify.app/:splat     200
 /blastula/*         https://blastula-pkg.netlify.app/:splat      200
-/flexdashboard/*    https://flexdashboard-pkg.netlify.app/:splat 200
 /gradethis/*        https://gradethis.netlify.app/:splat         200
 /rticles/*          https://rticles-pkg.netlify.app/:splat       200
 /ggcheck/*          https://ggcheck-pkg.netlify.app/:splat       200


### PR DESCRIPTION
Removes the redirect to the Netlify-hosted flexdashboard package site. The general `/* -> rstudio.github.io/:splat` should still work.

I'll continue to deploy both sites in flexdashboard's CI process until we know that the redirects are working correctl.