### PR TITLE
Add redirect following `connectapi` move to `posit-dev` org

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -9,5 +9,6 @@
 /rticles/*          https://rticles-pkg.netlify.app/:splat       200
 /ggcheck/*          https://ggcheck-pkg.netlify.app/:splat       200
 /tblcheck/*         https://tblcheck-pkg.netlify.app/:splat      200
+/connectapi/*       https://posit-dev.github.io/:splat           200
 
 /*                  https://rstudio.github.io/:splat             200


### PR DESCRIPTION
We're in the process of moving `connectapi` organizations, from `rstudio` to `posit-dev` (https://github.com/rstudio/connectapi/issues/352). It'll need a redirect for its `pkgs.rstudio.com` URL to continue to work.

I'm not in control of exactly when the move happens, so it's not possible for the changes to happen completely synchronously.

Let me know if you need any other info!